### PR TITLE
Add .NET Core App 2.2 & 3.0 as targets

### DIFF
--- a/run.cmd
+++ b/run.cmd
@@ -1,5 +1,5 @@
 @echo off
 pushd "%~dp0"
 echo>&2 WARNING! Working directory is: %~dp0
-dotnet run --no-launch-profile -p src -- %*
+dotnet run --no-launch-profile -f netcoreapp3.0 -p src -- %*
 popd

--- a/run.sh
+++ b/run.sh
@@ -2,4 +2,4 @@
 set -e
 cd "$(dirname "$0")"
 echo>&2 "WARNING! Working directory is: $(pwd)"
-dotnet run --no-launch-profile -p src -- "$@"
+dotnet run --no-launch-profile -f netcoreapp3.0 -p src -- "$@"

--- a/src/LinqPadless.csproj
+++ b/src/LinqPadless.csproj
@@ -5,7 +5,7 @@
     <Title>LinqPadless</Title>
     <OutputType>Exe</OutputType>
     <VersionPrefix>2.0.0</VersionPrefix>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp2.2;netcoreapp2.1</TargetFrameworks>
     <LangVersion>8</LangVersion>
     <AssemblyName>lpless</AssemblyName>
     <Summary>LINQPad Queries without LINQPad</Summary>


### PR DESCRIPTION
LINQPadless requires .NET Core run-time 2.1 installed run. This PR adds .NET Core App 2.2 & 3.0 as targets do it can run against any of those runtimes since it is compatible across all of them.
