### PR TITLE
Use lowercase letters in CI version suffix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ before_build:
 - dotnet --info
 build_script:
 - ps: >-
-    $id = $env:APPVEYOR_REPO_COMMIT_TIMESTAMP -replace '([-:]|\.0+Z)', ''
+    $id = ([datetimeoffset]$env:APPVEYOR_REPO_COMMIT_TIMESTAMP).ToUniversalTime().ToString('yyyyMMdd''t''HHmm')
 
     $id = $id.Substring(0, 13)
 


### PR DESCRIPTION
This PR is a workaround for the “[Cannot install preview versions of .NET Core Global tools on Linux](https://github.com/dotnet/cli/issues/9870)” issue with the .NET Core CLI. This fix is to use lowercase T as the separator between the commit date and time in the package version suffix.
