### PR TITLE
Fix process exit race condition on Ubuntu

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1098,6 +1098,8 @@ namespace LinqPadless
             foreach (var item in output.GetConsumingEnumerable())
                 yield return item;
 
+            process.WaitForExit();
+
             var exitCode = process.ExitCode;
             if (exitCode != 0)
                 throw errorSelector(exitCode);


### PR DESCRIPTION
This PR fixes the tests failing on Ubuntu, as seen in [build 51](https://ci.appveyor.com/project/raboof/linqpadless/builds/28805559/job/xfhf4uq7yj7gv064). All tests fail with the error message:

    Process must exit before requested information can be determined.

---
📎 [`log.txt`](https://github.com/atifaziz/LinqPadless/files/3837860/log.txt)
