### PR TITLE
Add publishing timeout options

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1123,16 +1123,16 @@ namespace LinqPadless
                 {
                     await Task.Delay(delay, heartbeatCancellationToken);
 
-                    TimeSpan span;
-                    lock (tsLock) span = DateTime.Now - lastDataTimestamp;
+                    TimeSpan durationSinceLastData;
+                    lock (tsLock) durationSinceLastData = DateTime.Now - lastDataTimestamp;
 
-                    if (span > timeout)
+                    if (durationSinceLastData > timeout)
                     {
                         timeoutCancellationTokenSource.Cancel();
                         break;
                     }
 
-                    delay = timeout - span;
+                    delay = timeout - durationSinceLastData;
                 }
             }
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1174,7 +1174,8 @@ namespace LinqPadless
             if (timedOut || !process.WaitForExit((int)timeout.TotalMilliseconds))
             {
                 process.Kill();
-                throw new TimeoutException();
+                throw new TimeoutException(
+                    $"Timeout expired waiting for process {process.Id} to {(timedOut ? "respond" : "exit")}.");
             }
 
             var exitCode = process.ExitCode;

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1140,9 +1140,7 @@ namespace LinqPadless
                 catch (OperationCanceledException) {} // expected so ignore
             }
 
-#pragma warning disable 4014
-            Heartbeat(); // fire and forget!
-#pragma warning restore 4014
+            var heartbeatTask = Heartbeat();
 
             var timedOut = false;
 
@@ -1166,6 +1164,7 @@ namespace LinqPadless
             }
 
             heartbeatCancellationTokenSource.Cancel();
+            heartbeatTask.GetAwaiter().GetResult(); // await graceful shutdown
 
             if (timedOut || !process.WaitForExit((int)timeout.TotalMilliseconds))
             {

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -22,6 +22,7 @@ namespace LinqPadless
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Collections.Immutable;
+    using System.ComponentModel;
     using System.Diagnostics;
     using System.Globalization;
     using System.IO;
@@ -1194,7 +1195,14 @@ namespace LinqPadless
                                         ? (int)executionTimeout.TotalMilliseconds
                                         : Timeout.Infinite))
             {
-                process.Kill();
+                try
+                {
+                    process.Kill();
+                }
+                catch (Win32Exception e) // If Kill call is made while the process is terminating,
+                {                        // a Win32Exception is thrown for "Access Denied" (2).
+                    Debug.WriteLine(e);
+                }
 
                 var error = $"Timeout expired waiting for process {process.Id} to {(isClinicallyDead ? "respond" : "exit")}.";
 

--- a/src/TimeSpanHms.cs
+++ b/src/TimeSpanHms.cs
@@ -1,0 +1,72 @@
+#region Copyright (c) 2019 Atif Aziz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+namespace LinqPadless
+{
+    using System;
+    using System.Globalization;
+    using System.Text.RegularExpressions;
+
+    static class TimeSpanHms
+    {
+        public static TimeSpan Parse(string input) =>
+            TryParse(input, out var value) ? value : throw new FormatException();
+
+        public static bool TryParse(string input, out TimeSpan value)
+        {
+            var match =
+                Regex.Match(input,
+                    @"^(   (?<h>[0-9]+) : (?<m>[0-9]+) : (?<s>[0-9]+)
+                         | (?<h>[0-9]+)[hH] ((?<m>[0-9]+)[mM])? ((?<s>[0-9]+)[sS])?
+                         | (?<m>[0-9]+)[mM] ((?<s>[0-9]+)[sS])?
+                         | (?<s>[0-9]+)[sS]
+                         )$",
+                    RegexOptions.IgnorePatternWhitespace |
+                    RegexOptions.ExplicitCapture);
+
+            switch (match.Success, match.Groups)
+            {
+                case (true, var groups):
+                    var h = ParseToken(groups["h"].Value);
+                    var m = ParseToken(groups["m"].Value);
+                    var s = ParseToken(groups["s"].Value);
+                    value = new TimeSpan(h, m, s);
+                    return true;
+
+                default:
+                    value = default;
+                    return false;
+            }
+
+            static int ParseToken(string s)
+                => s.Length > 0
+                 ? int.Parse(s, NumberStyles.None, CultureInfo.InvariantCulture)
+                 : 0;
+        }
+
+        public static string FormatHms(this TimeSpan duration)
+        {
+            return string.Concat(Format(duration.Days        , "d" ),
+                                 Format(duration.Hours       , "h" ),
+                                 Format(duration.Minutes     , "m" ),
+                                 Format(duration.Seconds     , "s" ),
+                                 Format(duration.Milliseconds, "ms"));
+
+            static string Format(int n, string unit) =>
+                n > 0 ? n.ToString(CultureInfo.InvariantCulture) + unit : string.Empty;
+        }
+    }
+}


### PR DESCRIPTION
I have noticed, especially with .NET Core SDK 3.0.100, that `dotnet publish` sometimes tends to hang. This PR adds options to time-out the publishing process.

This is a timeout for if `dotnet publish` appears clinically dead (producing no output) and another for if it takes too long to execute overall.
