### PR TITLE
Plain text scripts

### DIFF
--- a/src/AssemblyInfo.cs
+++ b/src/AssemblyInfo.cs
@@ -1,0 +1,1 @@
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Tests")]

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -100,6 +100,16 @@ namespace LinqPadless
             from e in source select e.Value;
     }
 
+    static class EnumeratorExtensions
+    {
+        public static bool TryRead<T>(this IEnumerator<T> enumerator, out T item)
+        {
+            bool moved;
+            (moved, item) = enumerator.MoveNext() ? (true, enumerator.Current) : default;
+            return moved;
+        }
+    }
+
     static class TupleExtensions
     {
         public static TResult MapItems<T1, T2, TResult>(this ValueTuple<T1, T2> tuple, Func<T1, T2, TResult> mapper) =>

--- a/src/Script.cs
+++ b/src/Script.cs
@@ -1,0 +1,210 @@
+#region Copyright (c) 2020 Atif Aziz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+namespace LinqPadless
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Text.RegularExpressions;
+    using System.Xml.Linq;
+    using CSharpMinifier;
+    using NuGet.Versioning;
+
+    static class Script
+    {
+        enum RewriterState
+        {
+            ScanReferenceOrUsing,
+            ScanUsing,
+            Using,
+            UsingTrailingSpace,
+            Skip,
+        }
+
+        public static (XElement, string) Transpile(LinqPadQueryLanguage language, string source)
+        {
+            var state = RewriterState.ScanReferenceOrUsing;
+            var imports = new List<string>();
+            var packages = new List<PackageReference>();
+            var sb = new StringBuilder(source.Length);
+            var ibs = new StringBuilder();
+
+            using var e = Scanner.Scan(source).GetEnumerator();
+            while (e.TryRead(out var token))
+            {
+                restart:
+                switch (state)
+                {
+                    case RewriterState.ScanReferenceOrUsing:
+                    {
+                        switch (token.Kind)
+                        {
+                            case TokenKind.PreprocessorDirective:
+                            {
+                                var directive = source.Substring(token.Start.Offset, token.Length);
+                                var match = Regex.Match(directive, @"^#r\s+""nuget:\s*(\w+(?:[.-]\w+)*)(?:\s*,\s*(.+))?""\s*$");
+                                if (!match.Success)
+                                {
+                                    state = RewriterState.Skip;
+                                    goto default;
+                                }
+                                var groups = match.Groups;
+                                var id = groups[1].Value;
+                                var group2 = groups[2];
+                                var version = group2.Success
+                                    ? NuGetVersion.TryParse(group2.Value, out var v) ? v
+                                      : throw new Exception($"Invalid package version in reference (line {token.Start.Line}): {directive}")
+                                    : null;
+                                packages.Add(new PackageReference(id, version, version?.IsPrerelease ?? false));
+                                while (e.TryRead(out var t) && t.Kind != TokenKind.NewLine) { /* NOP */ }
+                                break;
+                            }
+                            case TokenKind.Text:
+                            {
+                                state = RewriterState.ScanUsing;
+                                goto restart;
+                            }
+                            default:
+                            {
+                                sb.Append(source, token.Start.Offset, token.Length);
+                                break;
+                            }
+                        }
+                        break;
+                    }
+                    case RewriterState.ScanUsing:
+                    {
+                        switch (token.Kind)
+                        {
+                            case TokenKind.Text:
+                            {
+                                var text = source.AsSpan(token.Start.Offset, token.Length);
+                                if (text.SequenceEqual("using"))
+                                {
+                                    ibs.Clear();
+                                    state = RewriterState.Using;
+                                    break;
+                                }
+                                state = RewriterState.Skip;
+                                goto default;
+                            }
+                            case TokenKind.PreprocessorDirective:
+                            {
+                                var directive = source.AsSpan(token.Start.Offset, token.Length);
+                                if (directive.SequenceEqual("#r") || directive.StartsWith("#r "))
+                                    throw new Exception($"The reference on line {token.Start.Line} must precede the first import: {directive.ToString()}");
+                                goto default;
+                            }
+                            default:
+                            {
+                                sb.Append(source, token.Start.Offset, token.Length);
+                                break;
+                            }
+                        }
+                        break;
+                    }
+                    case RewriterState.Using:
+                    {
+                        switch (token.Kind)
+                        {
+                            case TokenKind.WhiteSpace:
+                            {
+                                if (ibs.Length > 0 && ibs[^1] != ' ')
+                                    ibs.Append(' ');
+                                break;
+                            }
+                            case TokenKind.MultiLineComment:
+                            {
+                                sb.Append(source, token.Start.Offset, token.Length);
+                                break;
+                            }
+                            case TokenKind.SingleLineComment:
+                            case TokenKind.NewLine:
+                            {
+                                while (char.IsWhiteSpace(ibs[^1]))
+                                    ibs.Length -= 1;
+                                imports.Add(ibs.ToString());
+                                state = RewriterState.UsingTrailingSpace;
+                                break;
+                            }
+                            case TokenKind.Text:
+                            {
+                                var text = source.AsSpan(token.Start.Offset, token.Length);
+
+                                var i = text.IndexOf(';');
+                                if (i < 0)
+                                {
+                                    ibs.Append(text);
+                                }
+                                else
+                                {
+                                    ibs.Append(text.Slice(0, i));
+                                    text = text.Slice(i + 1);
+                                    if (text.Length == 0)
+                                    {
+                                        imports.Add(ibs.ToString());
+                                        state = RewriterState.UsingTrailingSpace;
+                                    }
+                                    else if (text.SequenceEqual("using"))
+                                    {
+                                        ibs.Clear();
+                                    }
+                                    else
+                                    {
+                                        imports.Add(ibs.ToString());
+                                        sb.Append(text);
+                                        state = RewriterState.Skip;
+                                    }
+                                }
+                                break;
+                            }
+                            default:
+                            {
+                                throw new Exception($"Syntax error parsing import on line {token.Start.Line}, column {token.Start.Column}.");
+                            }
+                        }
+                        break;
+                    }
+                    case RewriterState.UsingTrailingSpace:
+                    {
+                        if (token.Kind.HasTraits(TokenKindTraits.WhiteSpace))
+                            break;
+                        state = RewriterState.ScanUsing;
+                        goto restart;
+                    }
+                    case RewriterState.Skip:
+                    {
+                        sb.Append(source, token.Start.Offset, token.Length);
+                        break;
+                    }
+                    default:
+                        throw new Exception("Internal implementation error.");
+                }
+            }
+
+            return (new XElement("Query", new XAttribute("Kind", language),
+                    from pr in packages
+                    select new XElement("NuGetReference",
+                                        pr.HasVersion ? new XAttribute("Version", pr.Version) : null,
+                                        pr.Id),
+                    from ns in imports
+                    select new XElement("Namespace", ns)),
+                    sb.ToString());
+        }
+    }
+}

--- a/tests/ScriptTests.cs
+++ b/tests/ScriptTests.cs
@@ -1,0 +1,176 @@
+namespace Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Text.RegularExpressions;
+    using LinqPadless;
+    using Markdig;
+    using Markdig.Syntax;
+    using Markdig.Syntax.Inlines;
+    using Xunit;
+    using static MoreLinq.Extensions.ZipLongestExtension;
+    using static MoreLinq.Extensions.IndexExtension;
+
+    public class ScriptTests
+    {
+        public enum QueryKind { Expression, Statements, Program }
+
+        //[Fact]
+        public void Test2()
+        {
+            foreach (var args in TestSource())
+                Test((TestRecord)args[0]);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestSource))]
+        public void Test(TestRecord record)
+        {
+            var kind = record.QueryKind;
+            var source = record.Source;
+            var expected = record.Expected;
+
+            var language = kind switch
+            {
+                QueryKind.Expression => LinqPadQueryLanguage.Expression,
+                QueryKind.Statements => LinqPadQueryLanguage.Statements,
+                QueryKind.Program => LinqPadQueryLanguage.Program
+            };
+
+            string actual;
+
+            if (record.IsError)
+            {
+                var e = Assert.Throws<Exception>(() => Script.Transpile(language, source));
+                actual = e.Message;
+            }
+            else
+            {
+                var (meta, code) = Script.Transpile(language, source);
+                actual = string.Join(Environment.NewLine, meta, string.Empty, code);
+            }
+
+            foreach (var (i, (exp, act)) in
+                Regex.Split(expected, @"\r?\n")
+                     .ZipLongest(Regex.Split(actual, @"\r?\n"),
+                                 ValueTuple.Create)
+                     .Index(1))
+            {
+                Assert.Equal((i, exp), (i, act));
+            }
+
+            Assert.Equal(Regex.Split(expected, @"\r?\n"), Regex.Split(actual, @"\r?\n"));
+
+        }
+
+        public sealed class TestRecord
+        {
+            public string    Title     { get; }
+            public QueryKind QueryKind { get; }
+            public string    Source    { get; }
+            public bool      IsError   { get; }
+            public string    Expected  { get; }
+
+            public TestRecord(string title, QueryKind queryKind, string source, bool isError, string expected)
+            {
+                Title = title;
+                QueryKind = queryKind;
+                Source = source;
+                IsError = isError;
+                Expected = expected;
+            }
+
+            public override string ToString() => Title;
+        }
+
+        public static TheoryData<TestRecord> TestSource()
+        {
+            using var stream = typeof(ScriptTests).Assembly.GetManifestResourceStream(typeof(ScriptTests), nameof(ScriptTests) + ".md");
+            using var reader = new StreamReader(stream);
+            var md = reader.ReadToEnd();
+            var document = Markdown.Parse(md);
+
+            var data = new TheoryData<TestRecord>();
+            var headings = new Stack<HeadingBlock>();
+
+            using var be = document.AsEnumerable().GetEnumerator();
+            while (be.TryRead(out var block))
+            {
+                restart:
+
+                if (!(block is HeadingBlock heading))
+                    continue;
+
+                while (headings.Count > 0 && heading.Level <= headings.Peek().Level)
+                    headings.Pop();
+                headings.Push(heading);
+                var title = string.Join(" / ", from h in headings.Reverse().Skip(1)
+                                               select ((LiteralInline)h.Inline.Single()).Content.ToString());
+                var kind = QueryKind.Expression;
+                var source = default(string);
+                var isError = false;
+                var expected = default(string);
+
+                while (true)
+                {
+                    var more = be.TryRead(out block);
+                    if (!more || block is HeadingBlock)
+                    {
+                        if (source != null || expected != null)
+                            data.Add(new TestRecord(title, kind, source, isError, expected));
+                        if (more)
+                            goto restart;
+                        break;
+                    }
+
+                    if (block is ParagraphBlock paragraph
+                        && paragraph.Inline.SingleOrDefault() is LiteralInline literal)
+                    {
+                        var i = block.Parent.IndexOf(block);
+                        var nextBlock = i + 1 < block.Parent.Count ? block.Parent[i + 1] : null;
+
+                        switch (literal.Content.ToString().Replace(" ", null).ToLowerInvariant())
+                        {
+                            case "suppose:" when nextBlock is ListBlock list:
+                            {
+                                var kinds =
+                                    from ListItemBlock item in list
+                                    select item.SingleOrDefault() is ParagraphBlock paragraph
+                                           && paragraph.Inline.SingleOrDefault() is LiteralInline literal
+                                        ? Regex.Match(literal.Content.ToString(), @"(\w+)\s+is\s+(\w+)")
+                                        : null
+                                    into m
+                                    where m?.Success ?? false
+                                    select KeyValuePair.Create(m.Groups[1].Value, m.Groups[2].Value) into e
+                                    where "kind".Equals(e.Key, StringComparison.OrdinalIgnoreCase)
+                                    select e.Value;
+                                kind = Enum.Parse<QueryKind>(kinds.Last(), true);
+                                break;
+                            }
+                            case "source:" when nextBlock is FencedCodeBlock code:
+                            {
+                                source = code.Lines.ToSlice().ToString();
+                                break;
+                            }
+                            case "expected:" when nextBlock is FencedCodeBlock code:
+                            {
+                                expected = code.Lines.ToSlice().ToString();
+                                break;
+                            }
+                            case "errorexpected:" when nextBlock is FencedCodeBlock code:
+                            {
+                                isError = true;
+                                expected = code.Lines.ToSlice().ToString();
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
+            return data;
+        }
+    }
+}

--- a/tests/ScriptTests.cs
+++ b/tests/ScriptTests.cs
@@ -17,13 +17,6 @@ namespace Tests
     {
         public enum QueryKind { Expression, Statements, Program }
 
-        //[Fact]
-        public void Test2()
-        {
-            foreach (var args in TestSource())
-                Test((TestRecord)args[0]);
-        }
-
         [Theory]
         [MemberData(nameof(TestSource))]
         public void Test(TestRecord record)

--- a/tests/ScriptTests.cs
+++ b/tests/ScriptTests.cs
@@ -25,7 +25,9 @@ namespace Tests
             var source = record.Source;
             var expected = record.Expected;
 
+#pragma warning disable 8509
             var language = kind switch
+#pragma warning restore 8509
             {
                 QueryKind.Expression => LinqPadQueryLanguage.Expression,
                 QueryKind.Statements => LinqPadQueryLanguage.Statements,

--- a/tests/ScriptTests.md
+++ b/tests/ScriptTests.md
@@ -1,0 +1,326 @@
+# Script Tests
+
+
+## Query Kinds
+
+
+### Expression
+
+Suppose:
+
+- kind is expression
+
+Source:
+
+```
+DateTime.Now
+```
+
+Expected:
+
+```
+<Query Kind="Expression" />
+
+DateTime.Now
+```
+
+
+### Statements
+
+Suppose:
+
+- kind is statements
+
+Source:
+
+```
+Console.WriteLine(DateTime.Now);
+```
+
+Expected:
+
+```
+<Query Kind="Statements" />
+
+Console.WriteLine(DateTime.Now);
+```
+
+
+### Program
+
+Suppose:
+
+- kind is program
+
+Source:
+
+```
+void Main()
+{
+    Console.WriteLine(DateTime.Now);
+}
+```
+
+Expected:
+
+```
+<Query Kind="Program" />
+
+void Main()
+{
+    Console.WriteLine(DateTime.Now);
+}
+```
+
+
+## Single import
+
+Source:
+
+```
+using System.Net.Http;
+
+DateTime.Now
+```
+
+Expected:
+
+```
+<Query Kind="Expression">
+  <Namespace>System.Net.Http</Namespace>
+</Query>
+
+DateTime.Now
+```
+
+
+## Multiple imports
+
+Source:
+
+```
+using System.Net.Http;
+using System.Security.Cryptography;
+
+DateTime.Now
+```
+
+Expected:
+
+```
+<Query Kind="Expression">
+  <Namespace>System.Net.Http</Namespace>
+  <Namespace>System.Security.Cryptography</Namespace>
+</Query>
+
+DateTime.Now
+```
+
+
+## Mixed types of imports
+
+Source:
+
+```
+using System.Net.Http;
+using System.Security.Cryptography;
+using static System.Math;
+using Int = System.Int32;
+
+DateTime.Now
+```
+
+Expected:
+
+```
+<Query Kind="Expression">
+  <Namespace>System.Net.Http</Namespace>
+  <Namespace>System.Security.Cryptography</Namespace>
+  <Namespace>static System.Math</Namespace>
+  <Namespace>Int = System.Int32</Namespace>
+</Query>
+
+DateTime.Now
+```
+
+
+## Imports without semi-colon termination
+
+Source:
+
+```
+using System.Net.Http
+using System.Security.Cryptography
+using static System.Math
+using Int = System.Int32
+DateTime.Now
+```
+
+Expected:
+
+```
+<Query Kind="Expression">
+  <Namespace>System.Net.Http</Namespace>
+  <Namespace>System.Security.Cryptography</Namespace>
+  <Namespace>static System.Math</Namespace>
+  <Namespace>Int = System.Int32</Namespace>
+</Query>
+
+DateTime.Now
+```
+
+
+## Spaced-out imports
+
+Whitespace between imports is discarded.
+
+Source:
+
+```
+using System.Net.Http
+
+using System.Security.Cryptography
+
+using static System.Math
+
+using Int = System.Int32
+
+DateTime.Now
+```
+
+Expected:
+
+```
+<Query Kind="Expression">
+  <Namespace>System.Net.Http</Namespace>
+  <Namespace>System.Security.Cryptography</Namespace>
+  <Namespace>static System.Math</Namespace>
+  <Namespace>Int = System.Int32</Namespace>
+</Query>
+
+DateTime.Now
+```
+
+
+## Commented-out imports
+
+Source:
+
+```
+using System.Net.Http
+//using System.Security.Cryptography
+using static System.Math
+//using Int = System.Int32
+
+DateTime.Now
+```
+
+Expected:
+
+```
+<Query Kind="Expression">
+  <Namespace>System.Net.Http</Namespace>
+  <Namespace>static System.Math</Namespace>
+</Query>
+
+//using System.Security.Cryptography
+//using Int = System.Int32
+
+DateTime.Now
+```
+
+
+## Comments on same line as import
+
+Source:
+
+```
+using System.Net.Http // this is a comment
+using static System.Math
+
+DateTime.Now
+```
+
+Expected:
+
+```
+<Query Kind="Expression">
+  <Namespace>System.Net.Http</Namespace>
+  <Namespace>static System.Math</Namespace>
+</Query>
+
+DateTime.Now
+```
+
+
+## NuGet references
+
+
+### With version
+
+Source:
+
+```
+#r "nuget: System.Reactive, 4.3.2"
+using System.Reactive.Linq;
+
+Observable.Range(1,10)
+```
+
+Expected:
+
+```
+<Query Kind="Expression">
+  <NuGetReference Version="4.3.2">System.Reactive</NuGetReference>
+  <Namespace>System.Reactive.Linq</Namespace>
+</Query>
+
+Observable.Range(1,10)
+```
+
+
+### Cannot follow imports
+
+Source:
+
+```
+using System.Reactive.Linq;
+#r "nuget: System.Reactive"
+
+Observable.Range(1,10)
+```
+
+Error expected:
+
+```
+The reference on line 2 must precede the first import: #r "nuget: System.Reactive"
+```
+
+### Commented-out
+
+Suppose:
+
+- kind is expression
+
+Source:
+
+```
+//#r "nuget: System.Reactive"
+using System.Reactive.Linq;
+//#r "nuget: System.Reactive"
+
+Observable.Range(1,10)
+```
+
+Expected:
+
+```
+<Query Kind="Expression">
+  <Namespace>System.Reactive.Linq</Namespace>
+</Query>
+
+//#r "nuget: System.Reactive"
+//#r "nuget: System.Reactive"
+
+Observable.Range(1,10)
+```

--- a/tests/TemplateTests.cs
+++ b/tests/TemplateTests.cs
@@ -29,11 +29,9 @@ public class TemplateTests
         var isWindows =    Environment.GetEnvironmentVariable("WINDIR") != null
                         && Environment.GetEnvironmentVariable("COMSPEC") != null;
 
-        return new DirectoryInfo(TestDirectoryPath)
-            .AncestorsAndSelf()
-            .Select(dir => Path.Combine(dir.FullName, "bin", BuildConfiguration, "netcoreapp3.1", isWindows ? "lpless.exe" : "lpless"))
-            .Where(File.Exists)
-            .First();
+        return Path.Combine(TestDirectoryPath, "..", "..", "..", "..",
+                            "bin", BuildConfiguration, "netcoreapp3.1",
+                            isWindows ? "lpless.exe" : "lpless");
     });
 
     readonly ITestOutputHelper _testOutput;

--- a/tests/Tests.csproj
+++ b/tests/Tests.csproj
@@ -7,13 +7,27 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Markdig" Version="0.18.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
 
   <ItemGroup>
     <None Include="linq\**" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Remove="ScriptTests.md" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="ScriptTests.md" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\LinqPadless.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR explores adding support for running plain text scripts as LINQPad's `lprun` does and as described in the **Plain Text Scripts** section of [LINQPad Command-Line and Scripting](https://www.linqpad.net/LPRun.aspx):

> ### Plain Text Scripts
>
> `lprun` will execute plain-text files if you tell it the language via the **-lang** switch. The valid options are:
>
> **Expression**, **Statements**, **Program**, **VBExpression**, **VBStatements**, **VBProgram**, **FSharpExpression**, **FSharpProgram**, **SQL**, **ESQL**
>
> The first three can be abbreviated to their first letter. For example, the following prints 24:
>
>     echo 12+12 > script.txt
>     lprun -lang=e script.txt
>
> `script.txt` is equivalent to a **.linq** file that looks like this:
>
> ```
> <Query Kind="Expression" />
>
> 12+12
> ```
>
> A **.linq** file is merely a text file with an XML header that describes properties of the query, such as its language, connection, namespaces to import, etc. Not having a header can save a bit of typing with ad-hoc scripts. It also lets you execute scripts written for scriptcs.