### PR TITLE
Fix Linux CI build (breaks due to install bug)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ install:
 - ps: if ($isWindows) { ./dotnet-install.ps1 -Runtime dotnet -Version 2.1.15 -SkipNonVersionedFiles }
 - sh: curl -OsSL https://dot.net/v1/dotnet-install.sh
 - sh: chmod +x dotnet-install.sh
-- sh: ./dotnet-install.sh --jsonfile global.json
+- sh: ./dotnet-install.sh --version 3.1.101
 - sh: ./dotnet-install.sh --runtime dotnet --version 2.1.15 --skip-non-versioned-files
 - sh: export PATH="$HOME/.dotnet:$PATH"
 before_build:


### PR DESCRIPTION
This PR fixes the build by explicitly stating the required SDK version for Linux CI build. `dotnet-install.sh` seems to have a bug where it resolves the following `global.json` (since c619d0025d8862c1af745072b39d33b25c386ec6):

```json
{
  "sdk": {
    "version": "3.1.101",
    "rollForward": "latestFeature"
  }
}
```

to the invalid URL `https://dotnetcli.azureedge.net/dotnet/Sdk/3.1.101rollForward:latestFeature/dotnet-dev-ubuntu.18.04-x64.3.1.101rollForward:latestFeature.tar.gz`.

