### PR TITLE
Forced TLS 1.2 for network connections

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -48,6 +48,8 @@ namespace LinqPadless
     {
         static partial void Wain(IEnumerable<string> args)
         {
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
             const string csx = "csx";
             const string exe = "exe";
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -362,6 +362,11 @@ namespace LinqPadless
 
             foreach (var nr in nrs)
             {
+                // See also: https://docs.microsoft.com/en-us/dotnet/framework/network-programming/tls
+                const SecurityProtocolType tls12 = SecurityProtocolType.Tls12;
+                if ((ServicePointManager.SecurityProtocol & tls12) != tls12)
+                    ServicePointManager.SecurityProtocol |= tls12;
+
                 var version = nr.Version;
                 if (version == null)
                 {

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -48,8 +48,6 @@ namespace LinqPadless
     {
         static partial void Wain(IEnumerable<string> args)
         {
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
-
             const string csx = "csx";
             const string exe = "exe";
 


### PR DESCRIPTION
Simplest fix to enforce TLS 1.2 in the old framework app, without doing major version upgrade. Fixes #49 