### PR TITLE
Use .NET SDK 8, targeting .NET LTS runtimes

### DIFF
--- a/.lpless/templates/template/ProgramTemplate.csproj
+++ b/.lpless/templates/template/ProgramTemplate.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>8</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/.lpless/templates/template/global.json
+++ b/.lpless/templates/template/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.101",
+    "version": "8.0.100",
     "rollForward": "latestFeature"
   }
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-ARG DOTNET_SDK_VERSION=3.1.101
-ARG PLATFORM=alpine3.10
+ARG DOTNET_SDK_VERSION=8.0.100
+ARG PLATFORM=alpine3.18
 
-FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNET_SDK_VERSION}-${PLATFORM} AS build
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_SDK_VERSION}-1-${PLATFORM} AS build
 
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=true
 ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
@@ -12,7 +12,7 @@ WORKDIR /project
 
 RUN dotnet pack -c Release src
 
-FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNET_SDK_VERSION}-${PLATFORM} AS tool
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_SDK_VERSION}-1-${PLATFORM} AS tool
 
 COPY --from=build /project/dist/*.nupkg /dist/
 COPY --from=build /project/etc/sourceless-nuget.config nuget.config
@@ -22,7 +22,7 @@ RUN dotnet tool install --global \
         --add-source dist \
         LinqPadless --version 2.0.0
 
-FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNET_SDK_VERSION}-${PLATFORM}
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_SDK_VERSION}-1-${PLATFORM}
 
 COPY --from=tool /root/.dotnet/tools /root/.dotnet/tools
 

--- a/LinqPadless.sln
+++ b/LinqPadless.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29209.62
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34330.188
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{6C9AA163-DA0D-4BB7-A988-5AAC0D700936}"
 	ProjectSection(SolutionItems) = preProject

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: '{build}'
 image:
-  - Visual Studio 2019
-  - Ubuntu
+  - Visual Studio 2022
+  - Ubuntu2204
 skip_commits:
   files:
     - Dockerfile
@@ -23,11 +23,9 @@ environment:
 install:
 - cmd: curl -OsSL https://dot.net/v1/dotnet-install.ps1
 - ps: if ($isWindows) { ./dotnet-install.ps1 -JsonFile global.json }
-- ps: if ($isWindows) { ./dotnet-install.ps1 -Runtime dotnet -Version 2.1.15 -SkipNonVersionedFiles }
 - sh: curl -OsSL https://dot.net/v1/dotnet-install.sh
 - sh: chmod +x dotnet-install.sh
-- sh: ./dotnet-install.sh --version 3.1.101
-- sh: ./dotnet-install.sh --runtime dotnet --version 2.1.15 --skip-non-versioned-files
+- sh: ./dotnet-install.sh --jsonfile global.json
 - sh: export PATH="$HOME/.dotnet:$PATH"
 before_build:
 - dotnet --info
@@ -40,7 +38,7 @@ build_script:
     if ($isWindows) { .\pack.cmd ci-$id } else { ./pack.sh ci-$id }
 test_script:
 - cmd: test.cmd
-- sh: ./test.sh
+- sh: DOTNET_ROOT="$HOME/.dotnet" ./test.sh
 - sh: docker build -t lpless .
 - sh: docker run --rm lpless
 artifacts:

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.101",
+    "version": "8.0.100",
     "rollForward": "latestFeature"
   }
 }

--- a/publish.cmd
+++ b/publish.cmd
@@ -4,8 +4,8 @@ pushd "%~dp0"
 call build
 set EXIT_CODE=%ERRORLEVEL%
 if not %EXIT_CODE%==0 goto :end
-for %%f in (3.1 2.1) do (
-    dotnet publish --no-restore --no-build -c Release -f netcoreapp%%f -o dist\bin\%%f src || goto :break
+for %%f in (8.0 6.0) do (
+    dotnet publish --no-restore --no-build -c Release -f net%%f -o dist\bin\%%f src || goto :break
 )
 :break
 set EXIT_CODE=%ERRORLEVEL%

--- a/publish.sh
+++ b/publish.sh
@@ -2,6 +2,6 @@
 set -e
 cd "$(dirname "$0")"
 ./build.sh
-for f in 3.1 2.1; do
-    dotnet publish --no-restore --no-build -c Release -f netcoreapp$f -o dist/bin/$f src
+for f in 8.0 6.0; do
+    dotnet publish --no-restore --no-build -c Release -f net$f -o dist/bin/$f src
 done

--- a/run.cmd
+++ b/run.cmd
@@ -1,5 +1,5 @@
 @echo off
 pushd "%~dp0"
 echo>&2 WARNING! Working directory is: %~dp0
-dotnet run --no-launch-profile -f netcoreapp3.1 -p src -- %*
+dotnet run --no-launch-profile -f net8.0 --project src -- %*
 popd

--- a/run.sh
+++ b/run.sh
@@ -2,4 +2,4 @@
 set -e
 cd "$(dirname "$0")"
 echo>&2 "WARNING! Working directory is: $(pwd)"
-dotnet run --no-launch-profile -f netcoreapp3.1 -p src -- "$@"
+dotnet run --no-launch-profile -f net8.0 --project src -- "$@"

--- a/src/InitCommand.cs
+++ b/src/InitCommand.cs
@@ -36,7 +36,6 @@ namespace LinqPadless
     using Optuple.Collections;
     using Optuple.Linq;
     using static MoreLinq.Extensions.ToDelimitedStringExtension;
-    using static MoreLinq.Extensions.MaxByExtension;
     using static Optuple.OptionModule;
     using static TryModule;
     using static OptionTag;
@@ -176,8 +175,8 @@ namespace LinqPadless
                             ListPackagesFromFileSystemFeed(feedDirPath)
                                 .Where(p => (searchPrereleases || !p.Version.IsPrerelease)
                                          && string.Equals(p.Id, id, StringComparison.OrdinalIgnoreCase))
-                                .MaxBy(p => p.Version)
-                                .FirstOrDefault();
+                                .DefaultIfEmpty()
+                                .MaxBy(p => p.Version);
                     }
                     else
                     {

--- a/src/LinqPadless.csproj
+++ b/src/LinqPadless.csproj
@@ -5,7 +5,7 @@
     <Title>LinqPadless</Title>
     <OutputType>Exe</OutputType>
     <VersionPrefix>2.0.0</VersionPrefix>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>8</LangVersion>
     <AssemblyName>lpless</AssemblyName>
     <Summary>LINQPad Queries without LINQPad</Summary>
@@ -57,7 +57,6 @@
     <PackageReference Include="morelinq" Version="3.2.0" />
     <PackageReference Include="NuGet.Versioning" Version="5.2.0" />
     <PackageReference Include="Optuple" Version="2.1.0" />
-    <PackageReference Include="IndexRange" Version="1.0.0" Condition="$(TargetFramework) == 'netcoreapp2.1'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -49,14 +49,12 @@ namespace LinqPadless
     using Optuple.RegularExpressions;
     using static Minifier;
     using static MoreLinq.Extensions.ChooseExtension;
-    using static MoreLinq.Extensions.DistinctByExtension;
     using static MoreLinq.Extensions.FoldExtension;
     using static MoreLinq.Extensions.ForEachExtension;
     using static MoreLinq.Extensions.IndexExtension;
     using static MoreLinq.Extensions.PartitionExtension;
     using static MoreLinq.Extensions.TakeUntilExtension;
     using static MoreLinq.Extensions.ToDelimitedStringExtension;
-    using static MoreLinq.Extensions.ToDictionaryExtension;
     using static OptionTag;
     using static Optuple.OptionModule;
     using MoreEnumerable = MoreLinq.MoreEnumerable;
@@ -307,7 +305,7 @@ namespace LinqPadless
 
             var minifierByExtension =
                 minifierTable.SelectMany(m => m.Extension, (m, ext) => KeyValuePair.Create(ext, m.Function))
-                             .ToDictionary(StringComparer.OrdinalIgnoreCase);
+                             .ToDictionary(e => e.Key, e => e.Value, StringComparer.OrdinalIgnoreCase);
 
             var hashSource =
                 MoreEnumerable

--- a/tests/TemplateTests.cs
+++ b/tests/TemplateTests.cs
@@ -31,7 +31,7 @@ public class TemplateTests
 
         return new DirectoryInfo(TestDirectoryPath)
             .AncestorsAndSelf()
-            .Select(dir => Path.Combine(dir.FullName, "bin", BuildConfiguration, "netcoreapp3.1", isWindows ? "lpless.exe" : "lpless"))
+            .Select(dir => Path.Combine(dir.FullName, "bin", BuildConfiguration, "net8.0", isWindows ? "lpless.exe" : "lpless"))
             .Where(File.Exists)
             .First();
     });

--- a/tests/Tests.csproj
+++ b/tests/Tests.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>8</LangVersion>
+    <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
This PR updates the solution to use .NET 8 SDK and target the latest LTS runtimes, version 6 and 8.