### PR TITLE
Address warnings about obsolete types/members

### DIFF
--- a/src/Help.cs
+++ b/src/Help.cs
@@ -27,7 +27,7 @@ namespace LinqPadless
 
     partial class Program
     {
-        static readonly Lazy<FileVersionInfo> CachedVersionInfo = Lazy.Create(() => FileVersionInfo.GetVersionInfo(new Uri(typeof(Program).Assembly.CodeBase).LocalPath));
+        static readonly Lazy<FileVersionInfo> CachedVersionInfo = Lazy.Create(() => FileVersionInfo.GetVersionInfo(typeof(Program).Assembly.Location));
         static FileVersionInfo VersionInfo => CachedVersionInfo.Value;
 
         static void Help(string command, MonoOptionSet options) =>

--- a/src/JavaScriptCompressor.cs
+++ b/src/JavaScriptCompressor.cs
@@ -467,9 +467,6 @@ namespace Jazmin
 
             public Exception(string message, System.Exception innerException) :
                 base(message, innerException) {}
-
-            protected Exception(SerializationInfo info, StreamingContext context) :
-                base(info, context) {}
         }
     }
 }

--- a/src/NDesk.Options.cs
+++ b/src/NDesk.Options.cs
@@ -481,7 +481,9 @@ namespace Mono.Options
 		}
 
 		protected OptionException (SerializationInfo info, StreamingContext context)
+#pragma warning disable SYSLIB0051
 			: base (info, context)
+#pragma warning restore SYSLIB0051
 		{
 			this.option = info.GetString ("OptionName");
 		}
@@ -490,10 +492,18 @@ namespace Mono.Options
 			get {return this.option;}
 		}
 
+#pragma warning disable SYSLIB0003
+		// SYSLIB0003: 'SecurityPermissionAttribute' is obsolete: 'Code Access Security is not supported or honored by the runtime.' (https://aka.ms/dotnet-warnings/SYSLIB0003)
+		// SYSLIB0003: 'SecurityAction' is obsolete: 'Code Access Security is not supported or honored by the runtime.' (https://aka.ms/dotnet-warnings/SYSLIB0003)
 		[SecurityPermission (SecurityAction.LinkDemand, SerializationFormatter = true)]
+#pragma warning restore SYSLIB0003
+#pragma warning disable CS0672 // Member overrides obsolete member
 		public override void GetObjectData (SerializationInfo info, StreamingContext context)
+#pragma warning restore CS0672 // Member overrides obsolete member
 		{
+#pragma warning disable SYSLIB0051 // 'Exception.GetObjectData(SerializationInfo, StreamingContext)' is obsolete: 'This API supports obsolete formatter-based serialization. It should not be called or extended by application code.' (https://aka.ms/dotnet-warnings/SYSLIB0051)
 			base.GetObjectData (info, context);
+#pragma warning restore SYSLIB0051
 			info.AddValue ("OptionName", option);
 		}
 	}

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -27,7 +27,7 @@ namespace LinqPadless
     using System.Globalization;
     using System.IO;
     using System.Linq;
-    using System.Net;
+    using System.Net.Http;
     using System.Reflection;
     using System.Runtime.InteropServices;
     using System.Security.Cryptography;
@@ -513,7 +513,7 @@ namespace LinqPadless
                 }
 
                 var env = psi.Environment;
-                env.Add("LPLESS_BIN_PATH", new Uri(Assembly.GetEntryAssembly().CodeBase).LocalPath);
+                env.Add("LPLESS_BIN_PATH", Assembly.GetEntryAssembly().Location);
                 env.Add("LPLESS_LINQ_FILE_PATH", queryPath);
                 env.Add("LPLESS_LINQ_FILE_HASH", hash);
 
@@ -586,14 +586,14 @@ namespace LinqPadless
                 log?.WriteLines(from r in query.MetaElement.Elements("Reference")
                                 select "Warning! Reference will be ignored: " + (string)r);
 
-                var wc = new WebClient();
+                using var httpClient = new HttpClient();
 
                 NuGetVersion GetLatestPackageVersion(string id, bool isPrereleaseAllowed)
                 {
                     var latestVersion = Program.GetLatestPackageVersion(id, isPrereleaseAllowed, url =>
                     {
                         log?.WriteLine(url.OriginalString);
-                        return wc.DownloadString(url);
+                        return httpClient.GetStringAsync(url).GetAwaiter().GetResult();
                     });
                     log?.WriteLine($"{id} -> {latestVersion}");
                     return latestVersion;


### PR DESCRIPTION
This PR fixes the following warnings about use of obsolete types/members:

    A:\LinqPadless\src\Help.cs(30,124): warning SYSLIB0012: 'Assembly.CodeBase' is obsolete: 'Assembly.CodeBase and Assembly.EscapedCodeBase are only included for .NET Framework compatibility. Use Assembly.Location.' (https://aka.ms/dotnet-warnings/SYSLIB0012) [A:\LinqPadless\src\LinqPadless.csproj::TargetFramework=net6.0]
    A:\LinqPadless\src\Help.cs(30,124): warning SYSLIB0012: 'Assembly.CodeBase' is obsolete: 'Assembly.CodeBase and Assembly.EscapedCodeBase are only included for .NET Framework compatibility. Use Assembly.Location.' (https://aka.ms/dotnet-warnings/SYSLIB0012) [A:\LinqPadless\src\LinqPadless.csproj::TargetFramework=net8.0]
    A:\LinqPadless\src\NDesk.Options.cs(493,4): warning SYSLIB0003: 'SecurityPermissionAttribute' is obsolete: 'Code Access Security is not supported or honored by the runtime.' (https://aka.ms/dotnet-warnings/SYSLIB0003) [A:\LinqPadless\src\LinqPadless.csproj::TargetFramework=net6.0]
    A:\LinqPadless\src\NDesk.Options.cs(493,4): warning SYSLIB0003: 'SecurityPermissionAttribute' is obsolete: 'Code Access Security is not supported or honored by the runtime.' (https://aka.ms/dotnet-warnings/SYSLIB0003) [A:\LinqPadless\src\LinqPadless.csproj::TargetFramework=net8.0]
    A:\LinqPadless\src\NDesk.Options.cs(493,24): warning SYSLIB0003: 'SecurityAction' is obsolete: 'Code Access Security is not supported or honored by the runtime.' (https://aka.ms/dotnet-warnings/SYSLIB0003) [A:\LinqPadless\src\LinqPadless.csproj::TargetFramework=net6.0]
    A:\LinqPadless\src\NDesk.Options.cs(493,24): warning SYSLIB0003: 'SecurityAction' is obsolete: 'Code Access Security is not supported or honored by the runtime.' (https://aka.ms/dotnet-warnings/SYSLIB0003) [A:\LinqPadless\src\LinqPadless.csproj::TargetFramework=net8.0]
    A:\LinqPadless\src\NDesk.Options.cs(494,24): warning CS0672: Member 'OptionException.GetObjectData(SerializationInfo, StreamingContext)' overrides obsolete member 'Exception.GetObjectData(SerializationInfo, StreamingContext)'. Add the Obsolete attribute to 'OptionException.GetObjectData(SerializationInfo, StreamingContext)'. [A:\LinqPadless\src\LinqPadless.csproj::TargetFramework=net8.0]
    A:\LinqPadless\src\NDesk.Options.cs(484,4): warning SYSLIB0051: 'Exception.Exception(SerializationInfo, StreamingContext)' is obsolete: 'This API supports obsolete formatter-based serialization. It should not be called or extended by application code.' (https://aka.ms/dotnet-warnings/SYSLIB0051) [A:\LinqPadless\src\LinqPadless.csproj::TargetFramework=net8.0]
    A:\LinqPadless\src\NDesk.Options.cs(496,4): warning SYSLIB0051: 'Exception.GetObjectData(SerializationInfo, StreamingContext)' is obsolete: 'This API supports obsolete formatter-based serialization. It should not be called or extended by application code.' (https://aka.ms/dotnet-warnings/SYSLIB0051) [A:\LinqPadless\src\LinqPadless.csproj::TargetFramework=net8.0]
    A:\LinqPadless\src\JavaScriptCompressor.cs(471,83): warning SYSLIB0051: 'Exception.Exception(SerializationInfo, StreamingContext)' is obsolete: 'This API supports obsolete formatter-based serialization. It should not be called or extended by application code.' (https://aka.ms/dotnet-warnings/SYSLIB0051) [A:\LinqPadless\src\LinqPadless.csproj::TargetFramework=net8.0]
    A:\LinqPadless\src\Program.cs(516,52): warning SYSLIB0012: 'Assembly.CodeBase' is obsolete: 'Assembly.CodeBase and Assembly.EscapedCodeBase are only included for .NET Framework compatibility. Use Assembly.Location.' (https://aka.ms/dotnet-warnings/SYSLIB0012) [A:\LinqPadless\src\LinqPadless.csproj::TargetFramework=net6.0]
    A:\LinqPadless\src\Program.cs(516,52): warning SYSLIB0012: 'Assembly.CodeBase' is obsolete: 'Assembly.CodeBase and Assembly.EscapedCodeBase are only included for .NET Framework compatibility. Use Assembly.Location.' (https://aka.ms/dotnet-warnings/SYSLIB0012) [A:\LinqPadless\src\LinqPadless.csproj::TargetFramework=net8.0]
    A:\LinqPadless\src\Program.cs(589,26): warning SYSLIB0014: 'WebClient.WebClient()' is obsolete: 'WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.' (https://aka.ms/dotnet-warnings/SYSLIB0014) [A:\LinqPadless\src\LinqPadless.csproj::TargetFramework=net6.0]
    A:\LinqPadless\src\Program.cs(589,26): warning SYSLIB0014: 'WebClient.WebClient()' is obsolete: 'WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.' (https://aka.ms/dotnet-warnings/SYSLIB0014) [A:\LinqPadless\src\LinqPadless.csproj::TargetFramework=net8.0]
